### PR TITLE
Add a UUID to server.Request & add withHeaders helper to server.Response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 scala:
-  - 2.10.4
-  - 2.11.2
+  - 2.11.7
 jdk:
   - oraclejdk7
   - oraclejdk8

--- a/src/main/scala/fm/http/server/Request.scala
+++ b/src/main/scala/fm/http/server/Request.scala
@@ -15,7 +15,7 @@
  */
 package fm.http.server
 
-import fm.common.{IP, Logging, QueryParams}
+import fm.common.{IP, Logging, QueryParams, UUID}
 import fm.common.Implicits._
 import fm.http._
 import java.io.Closeable
@@ -51,7 +51,10 @@ final class Request (
   
   // Note - This is ONLY accessed via RequestLocal and synchronization is done there
   private[server] lazy val requestLocalMap: IdentityHashMap[RequestLocal[_],AnyRef] = new IdentityHashMap()
-  
+
+  // Generate a unique request id that can be referenced, lazy to avoid generating it if we don't need/use it
+  lazy val id: UUID = UUID()
+
   /**
    * This future is completed when the request has been fully processed
    */

--- a/src/main/scala/fm/http/server/Response.scala
+++ b/src/main/scala/fm/http/server/Response.scala
@@ -64,6 +64,8 @@ object Response {
 sealed trait Response extends Message {
   def status: Status
   def headers: Headers
+
+  def withHeaders(headerValues: (String, Any)*): Response
 }
 
 /**
@@ -75,6 +77,8 @@ final case class FullResponse(status: Status, headers: Headers = Headers.empty, 
     r.headers().add(headers.nettyHeaders)
     r
   }
+
+  def withHeaders(headerValues: (String, Any)*): FullResponse = copy(headers = headers.withHeaders(headerValues:_*))
 }
 
 /**
@@ -86,6 +90,8 @@ final case class AsyncResponse(status: Status, headers: Headers, head: LinkedHtt
     r.headers().add(headers.nettyHeaders)
     r
   }
+
+  def withHeaders(headerValues: (String, Any)*): AsyncResponse = copy(headers = headers.withHeaders(headerValues:_*))
 }
 
 /**
@@ -97,6 +103,8 @@ final case class FileResponse(status: Status, headers: Headers, file: File) exte
     r.headers().add(headers.nettyHeaders)
     r
   }
+
+  def withHeaders(headerValues: (String, Any)*): FileResponse = copy(headers = headers.withHeaders(headerValues:_*))
 }
 
 /**
@@ -108,4 +116,6 @@ final case class InputStreamResponse(status: Status, headers: Headers, input: In
     r.headers().add(headers.nettyHeaders)
     r
   }
+
+  def withHeaders(headerValues: (String, Any)*): InputStreamResponse = copy(headers = headers.withHeaders(headerValues:_*))
 }


### PR DESCRIPTION
Intended usage pattern:
def request: Request
def res: Future[Response]
res.map{ r: Response => r.withHeaders("FM-Request-ID" -> request.id.toString) }

Requires the Hex/Base64 UUID patch/change for fm-common
