### PR TITLE
Fix the basic auth client authoriation header

### DIFF
--- a/src/main/scala/fm/http/Headers.scala
+++ b/src/main/scala/fm/http/Headers.scala
@@ -739,15 +739,6 @@ final case class MutableHeaders(nettyHeaders: HttpHeaders = new DefaultHttpHeade
   def xUACompatible_=(v: Option[String]): Unit = set(NonStandardNames.X_UA_COMPATIBLE, v)
 
   //
-  // Authorization
-  //
-
-  def basicAuthorization_=(userPass: (String,String)): Unit = {
-    val (user, pass) = userPass
-    Headers.makeBasicAuthorization(user, pass)
-  }
-
-  //
   // Private Helpers
   //
 

--- a/src/main/scala/fm/http/Headers.scala
+++ b/src/main/scala/fm/http/Headers.scala
@@ -130,7 +130,7 @@ object Headers {
     case ex: Exception => None
   }
   
-  def makeBasicAuthorization(user: String, pass: String): String = Base64.encodeBytes((user+":"+pass).getBytes(StandardCharsets.ISO_8859_1))
+  def makeBasicAuthorization(user: String, pass: String): String = "Basic "+Base64.encodeBytes((user+":"+pass).getBytes(StandardCharsets.ISO_8859_1))
   
   /**
    * Given the value of the WWW-Authenticate or Authorization headers parse the Digest auth params


### PR DESCRIPTION
This matches the behavior of the digest auth `makeDigestAuthorization`  I tried to look for other references..specifically I'm not sure what: https://github.com/frugalmechanic/fm-http/blob/bd8ca492e883de4968d806ac4b6c7d926fa4b5fa/src/main/scala/fm/http/Headers.scala#L745-L748 does 