### PR TITLE
Added ability to perform arbitrary response header modifications out-of-band from how the Response instance gets constructed

### DIFF
--- a/src/main/scala/fm/http/Headers.scala
+++ b/src/main/scala/fm/http/Headers.scala
@@ -438,6 +438,8 @@ final case class MutableHeaders(nettyHeaders: HttpHeaders = new DefaultHttpHeade
   def setLong(name: String, value: Long): Unit = set(name, value.toString)
   def setLong(name: String, value: Option[Long]): Unit = set(name, value.map{ _.toString })
 
+  def remove(name: String): Unit = nettyHeaders.remove(name)
+
   def withHeaders(headerValues: (String, Any)*): MutableHeaders = {
     headerValues.foreach { case (name, value) =>
       value match {

--- a/src/main/scala/fm/http/Headers.scala
+++ b/src/main/scala/fm/http/Headers.scala
@@ -195,7 +195,7 @@ sealed trait Headers extends IndexedSeqProxy[(String, String)] {
   
   /** These are the client side cookies that are being sent with the request */
   def addCookie(c: Cookie): Headers = {
-    withSetCookies(cookies.filterNot{ _.name === c.name } :+ c)
+    withCookies(cookies.filterNot{ _.name === c.name } :+ c)
   }
   
   /** These are the server side cookies that are being sent with the response */

--- a/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
+++ b/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
@@ -214,6 +214,19 @@ final class NettyHttpServerPipelineHandler(channelGroup: ChannelGroup, execution
       response.headers().add(header, request.id.toHex())
     }
 
+    // Add in any overrides
+    Response.headerModifications.get(request) match {
+      case None =>
+        // Nothing to do
+
+      case Some(builder) =>
+        // Wrap the Netty HttpHeaders in our MutableHeaders
+        val headers: MutableHeaders = MutableHeaders(response.headers())
+
+        // Apply any mutations to the headers (which will modify the underlying netty HttpHeaders)
+        builder.result.foreach{ f: (MutableHeaders => Unit) => f(headers) }
+    }
+
     response
   }
   

--- a/src/main/scala/fm/http/server/Request.scala
+++ b/src/main/scala/fm/http/server/Request.scala
@@ -59,9 +59,10 @@ final class Request (
   val id: UUID = UUID()
   
   private[this] val completedPromise: Promise[Unit] = Promise()
-  
-  // Note - This is ONLY accessed via RequestLocal and synchronization is done there
-  private[server] lazy val requestLocalMap: IdentityHashMap[RequestLocal[_],AnyRef] = new IdentityHashMap()
+
+  // This is ONLY accessed by the RequestLocal class (synchronization is performed there)
+  // This is initialized lazily to avoid creating the IdentityHashMap if we never store anything in it.
+  private[server] var requestLocalMap: IdentityHashMap[RequestLocal[_],AnyRef] = null
   
   /**
    * This future is completed when the request has been fully processed

--- a/src/test/scala/fm/http/server/TestRequestLocal.scala
+++ b/src/test/scala/fm/http/server/TestRequestLocal.scala
@@ -1,0 +1,150 @@
+package fm.http.server
+
+import fm.common.IP
+import io.netty.handler.codec.http.HttpMethod
+import org.scalatest.{FunSuite, Matchers}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+final class TestRequestLocal extends FunSuite with Matchers {
+
+  private def makeDummyRequest(): Request = Request.dummy(IP.empty, HttpMethod.GET, "/dummy")
+
+  private val requestLocal: RequestLocal[String] = new RequestLocal()
+
+  private object requestLocalWithDefault extends RequestLocal[String] {
+    override def initialValue(implicit request: Request): Option[String] = Some("default_value")
+  }
+
+  test("apply - NoSuchElementException") {
+    implicit val request: Request = makeDummyRequest()
+    an [NoSuchElementException] should be thrownBy requestLocal()
+  }
+
+  test("apply - initialValue") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocalWithDefault() should equal ("default_value")
+  }
+
+  test("set - requestLocal") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocal.set("foo")
+    checkValue(requestLocal, "foo")
+    requestLocal.set("bar")
+    checkValue(requestLocal, "bar")
+  }
+
+  test("set - requestLocalWithDefault") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocalWithDefault.set("foo")
+    checkValue(requestLocalWithDefault, "foo")
+    requestLocalWithDefault.set("bar")
+    checkValue(requestLocalWithDefault, "bar")
+  }
+
+  test("set - Some - requestLocal") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocal.set(Some("foo"))
+    checkValue(requestLocal, "foo")
+    requestLocal.set(Some("bar"))
+    checkValue(requestLocal, "bar")
+  }
+
+  test("set - Some - requestLocalWithDefault") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocalWithDefault.set(Some("foo"))
+    checkValue(requestLocalWithDefault, "foo")
+    requestLocalWithDefault.set(Some("bar"))
+    checkValue(requestLocalWithDefault, "bar")
+  }
+
+  test("set - None - requestLocal") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocal.set(None)
+    requestLocal.hasValue should equal (false)
+  }
+
+  test("set - None - requestLocalWithDefault") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocalWithDefault.set(None)
+    requestLocalWithDefault.hasValue should equal (false)
+  }
+
+  test("setIfNotExists - requestLocal") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocal.setIfNotExists("foo")
+    checkValue(requestLocal, "foo")
+  }
+
+  test("setIfNotExists - requestLocalWithDefault") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocalWithDefault.setIfNotExists("foo")
+    checkValue(requestLocalWithDefault, "foo")
+  }
+
+  test("getOrElseUpdate - requestLocal") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocal.getOrElseUpdate("foo") should equal ("foo")
+    checkValue(requestLocal, "foo")
+  }
+
+  test("getOrElseUpdate - requestLocalWithDefault") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocalWithDefault.getOrElseUpdate("foo") should equal ("foo")
+    checkValue(requestLocalWithDefault, "foo")
+  }
+
+  test("getOrElseUpdate - null - requestLocal") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocal.getOrElseUpdate(null: String) should equal (null)
+    requestLocal.hasValue should equal (false)
+  }
+
+  test("getOrElseUpdate - null - requestLocalWithDefault") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocalWithDefault.getOrElseUpdate(null: String) should equal (null)
+    requestLocalWithDefault.hasValue should equal (false)
+  }
+
+  test("getOrElseUpdate - None - requestLocal") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocal.getOrElseUpdate(None) should equal (None)
+    requestLocal.hasValue should equal (false)
+  }
+
+  test("getOrElseUpdate - None - requestLocalWithDefault") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocalWithDefault.getOrElseUpdate(None) should equal (None)
+    requestLocalWithDefault.hasValue should equal (false)
+  }
+
+  test("remove - requestLocal") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocal.remove()
+    requestLocal.hasValue should equal (false)
+    requestLocal.set("foo")
+    checkValue(requestLocal, "foo")
+    requestLocal.remove()
+    requestLocal.hasValue should equal (false)
+  }
+
+  test("remove - requestLocalWithDefault") {
+    implicit val request: Request = makeDummyRequest()
+    requestLocalWithDefault.remove()
+    requestLocalWithDefault.hasValue should equal (false)
+    requestLocalWithDefault.set("foo")
+    checkValue(requestLocalWithDefault, "foo")
+    requestLocalWithDefault.remove()
+    requestLocalWithDefault.hasValue should equal (false)
+  }
+
+  private def checkValue(local: RequestLocal[String], value: String)(implicit request: Request): Unit = {
+    local.hasValue should equal(true)
+    local.get should equal (Some(value))
+    local() should equal (value)
+    local.setIfNotExists("BAD_VALUE")
+    local() should equal (value)
+    local.getOrElseUpdate("BAD_VALUE") should equal (value)
+    local.getOrElseUpdate(Some("BAD_VALUE")) should equal (Some(value))
+  }
+
+}


### PR DESCRIPTION
Here is what I'm thinking about for how to make arbitrary header modifications.

Usage would be like (assuming you have an `implicit request: Request` in scope):

```scala
Response.modifyHeaders{ headers: MutableHeaders =>
  headers.addSetCookie(???)
}
```

Or more concisely for the cookie use case:

```scala
Response.addCookie(c)
```

Or for adding a header:

```scala
Response.addHeader("X-Whatever", "foo")
```