### PR TITLE
Add a Response.saveAs that takes a ByteBuf

### DIFF
--- a/src/main/scala/fm/http/server/Response.scala
+++ b/src/main/scala/fm/http/server/Response.scala
@@ -163,6 +163,16 @@ object Response {
     headers.contentDispositionAttachmentFileName = saveAsName
     RandomAccessFileResponse(Status.OK, headers, raf)
   }
+
+  def saveAs(buf: ByteBuf, saveAsName: String): Response = saveAs(buf, saveAsName, MimeTypes.forPath(saveAsName).getOrElse{ MimeTypes.BINARY })
+
+  def saveAs(buf: ByteBuf, saveAsName: String, contentType: String): Response = {
+    val headers: MutableHeaders = MutableHeaders()
+    headers.contentType = contentType
+    headers.contentDispositionAttachmentFileName = saveAsName
+    Ok(headers, buf)
+  }
+
 }
 
 sealed trait Response extends Message {


### PR DESCRIPTION
the response from calling a lambda returns a `java.nio.ByteBuffer` so I'd like to just use the `Unpooled.wrappedBuffer(ByteBuffer)` on it instead of saving to a temporary file 