### PR TITLE
Cleaning up usages of parameter default values

### DIFF
--- a/src/main/scala/fm/http/PostData.scala
+++ b/src/main/scala/fm/http/PostData.scala
@@ -49,7 +49,9 @@ sealed trait PostData {
   final def length: Long = self.length()
   
   /** The InputStreamResource for reading this data */
-  def inputStreamResource(autoDecompress: Boolean = true, autoBuffer: Boolean = true): InputStreamResource
+  final def inputStreamResource(): InputStreamResource = inputStreamResource(true, true)
+  final def inputStreamResource(autoDecompress: Boolean): InputStreamResource = inputStreamResource(autoDecompress, true)
+  def inputStreamResource(autoDecompress: Boolean, autoBuffer: Boolean): InputStreamResource
 
   final def value: String = self.getString()
   
@@ -60,7 +62,7 @@ sealed trait PostData {
 sealed trait MemoryPostData extends PostData {
   protected final def resource: Resource[InputStream] = MultiUseResource{ new ByteBufInputStream(self.getByteBuf) }
   
-  final def inputStreamResource(autoDecompress: Boolean = true, autoBuffer: Boolean = true): InputStreamResource = InputStreamResource(resource, autoDecompress = autoDecompress, autoBuffer = autoBuffer)
+  final def inputStreamResource(autoDecompress: Boolean, autoBuffer: Boolean): InputStreamResource = InputStreamResource(resource, autoDecompress = autoDecompress, autoBuffer = autoBuffer)
 }
 
 sealed trait DiskPostData extends PostData {  
@@ -86,7 +88,7 @@ final case class MemoryPostAttribute(protected val self: netty.Attribute) extend
 final case class DiskPostAttribute(protected val self: netty.Attribute) extends PostAttribute with DiskPostData {
   require(!self.isInMemory, "Can't use an isInMemory=true instance of DiskAttribute with DiskPostAttribute")
   
-  def inputStreamResource(autoDecompress: Boolean = true, autoBuffer: Boolean = true): InputStreamResource = {
+  def inputStreamResource(autoDecompress: Boolean, autoBuffer: Boolean): InputStreamResource = {
     InputStreamResource.forFile(file, autoDecompress = autoDecompress, autoBuffer = autoBuffer)
   }
 }
@@ -98,7 +100,7 @@ final case class MemoryFileUpload(protected val self: netty.FileUpload) extends 
 final case class DiskFileUpload(protected val self: netty.FileUpload) extends FileUpload with DiskPostData {
   require(!self.isInMemory, "Can't use an isInMemory=true instance of FileUpload with DiskFileUpload")
   
-  def inputStreamResource(autoDecompress: Boolean = true, autoBuffer: Boolean = true): InputStreamResource = {
+  def inputStreamResource(autoDecompress: Boolean, autoBuffer: Boolean): InputStreamResource = {
     InputStreamResource.forFile(file, fileName.getOrElse(""), autoDecompress = autoDecompress, autoBuffer = autoBuffer)
   }
 }

--- a/src/main/scala/fm/http/client/DefaultHttpClient.scala
+++ b/src/main/scala/fm/http/client/DefaultHttpClient.scala
@@ -130,10 +130,41 @@ object DefaultHttpClient extends Logging {
       
     }
   }
+
+  @deprecated("proxy is now a required constructor parameter", "0.31.0") def apply(
+    defaultMaxLength: Long,
+    defaultHeaders: Headers,
+    useConnectionPool: Boolean,  // Should we re-use connections? (Use HTTP Keep Alive?)
+    maxConnectionsPerHost: Int,  // Only applies if useConnectionPool is true
+    maxRequestQueuePerHost: Int, // Only applies if useConnectionPool is true
+    maxConnectionIdleDuration: FiniteDuration,
+    defaultResponseTimeout: Duration, // The maximum time to wait for a Response
+    defaultConnectTimeout: Duration, // The maximum time to wait to connect to a server
+    defaultCharset: Charset, // The default charset to use (if none is specified in the response) when converting responses to strings
+    followRedirects: Boolean, // Should 301/302 redirects be followed for GET or HEAD requests?
+    maxRedirectCount: Int, // The maximum number of 301/302 redirects to follow for a GET or HEAD request
+    disableSSLCertVerification: Boolean, // Do not verify SSL certs (SHOULD NOT USE IN PRODUCTION)
+    autoDecompress: Boolean,
+  ): DefaultHttpClient = DefaultHttpClient(
+    None,
+    defaultMaxLength,
+    defaultHeaders,
+    useConnectionPool,
+    maxConnectionsPerHost,
+    maxRequestQueuePerHost,
+    maxConnectionIdleDuration,
+    defaultResponseTimeout,
+    defaultConnectTimeout,
+    defaultCharset,
+    followRedirects,
+    maxRedirectCount,
+    disableSSLCertVerification,
+    autoDecompress: Boolean,
+  )
 }
 
 final case class DefaultHttpClient(
-  proxy: Option[ProxyOptions] = None,
+  proxy: Option[ProxyOptions],
   defaultMaxLength: Long,
   defaultHeaders: Headers,
   useConnectionPool: Boolean,  // Should we re-use connections? (Use HTTP Keep Alive?)
@@ -146,7 +177,7 @@ final case class DefaultHttpClient(
   followRedirects: Boolean, // Should 301/302 redirects be followed for GET or HEAD requests?
   maxRedirectCount: Int, // The maximum number of 301/302 redirects to follow for a GET or HEAD request
   disableSSLCertVerification: Boolean, // Do not verify SSL certs (SHOULD NOT USE IN PRODUCTION)
-  autoDecompress: Boolean
+  autoDecompress: Boolean,
 ) extends HttpClient with Logging {
   import DefaultHttpClient.{EndPoint, TimeoutTask, workerGroup}
   

--- a/src/main/scala/fm/http/client/NettyHttpClientPipelineHandler.scala
+++ b/src/main/scala/fm/http/client/NettyHttpClientPipelineHandler.scala
@@ -145,7 +145,7 @@ final class NettyHttpClientPipelineHandler(channelGroup: ChannelGroup, execution
   private def channelReadHttpResponse(nettyResponse: HttpResponse, content: Future[Option[LinkedHttpContent]])(implicit ctx: ChannelHandlerContext): Unit = {
     require(null ne responsePromise, "No promise to receive the HttpResponse")
     
-    val contentReader: LinkedHttpContentReader = LinkedHttpContentReader(need100Continue = false, content)
+    val contentReader: LinkedHttpContentReader = LinkedHttpContentReader(need100Continue = false, head = content)
     
     val response: AsyncResponse = new AsyncResponse(nettyResponse, contentReader)
     
@@ -300,8 +300,10 @@ final class NettyHttpClientPipelineHandler(channelGroup: ChannelGroup, execution
     failPromises(cause)(ctx)
     ctx.close()
   }
-  
-  private def trace(name: String, ex: Throwable = null)(implicit ctx: ChannelHandlerContext): Unit = {
+
+  private def trace(name: String)(implicit ctx: ChannelHandlerContext): Unit = trace(name, null)
+
+  private def trace(name: String, ex: Throwable)(implicit ctx: ChannelHandlerContext): Unit = {
     if (logger.isTraceEnabled) logger.trace(s"$id - $name - ${ctx.channel}", ex)
   }
 }

--- a/src/main/scala/fm/http/server/HttpServer.scala
+++ b/src/main/scala/fm/http/server/HttpServer.scala
@@ -55,13 +55,17 @@ object HttpServer {
       case ex: Throwable => logger.error(s"Caught Exception in WebServer ($name) Shutdown Hook: "+ ex)
     }
   }
+
+  def apply(router: RequestRouter, authKey: String): HttpServer = HttpServer(8080, router, authKey)
+  def apply(router: RequestRouter, authKey: String, serverOptions: HttpServerOptions): HttpServer = HttpServer(8080, router, authKey, serverOptions)
+  def apply(port: Int, router: RequestRouter, authKey: String): HttpServer = HttpServer(port, router, authKey, HttpServerOptions.default)
 }
 
 final case class HttpServer (
-  port: Int = 8080,
+  port: Int,
   router: RequestRouter,
   authKey: String,
-  serverOptions: HttpServerOptions = HttpServerOptions.default
+  serverOptions: HttpServerOptions
 ) extends Logging {
   private[this] val name: String = s"WebServer on Port $port"
   private[this] val shutdownHookThread: Thread = new HttpServer.ShutdownHookThread(name, this)

--- a/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
+++ b/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
@@ -464,8 +464,10 @@ final class NettyHttpServerPipelineHandler(channelGroup: ChannelGroup, execution
     if (null != contentBuilder) contentBuilder += cause
     ctx.close()
   }
-  
-  private def trace(name: String, ex: Throwable = null)(implicit ctx: ChannelHandlerContext): Unit = {
+
+  private def trace(name: String)(implicit ctx: ChannelHandlerContext): Unit = trace(name, null)
+
+  private def trace(name: String, ex: Throwable)(implicit ctx: ChannelHandlerContext): Unit = {
     if (logger.isTraceEnabled) logger.trace(s"$id - $name - ${ctx.channel}", ex)
   }
 }

--- a/src/main/scala/fm/http/server/ReloadingRequestRouter.scala
+++ b/src/main/scala/fm/http/server/ReloadingRequestRouter.scala
@@ -8,15 +8,21 @@ import fm.common.Logging
  * 
  * For best results limit the scope of the reloadablePackages.
  */
+
+object ReloadingRequestRouter {
+  def apply(className: String, reloadablePackages: Seq[String]): ReloadingRequestRouter = apply(className, reloadablePackages, classOf[ReloadingRequestRouter].getClassLoader)
+  def apply(className: String, reloadablePackages: Seq[String], parent: ClassLoader): ReloadingRequestRouter = apply(className, reloadablePackages, parent, false)
+}
+
 final case class ReloadingRequestRouter(
   /* The fully qualified className of the RequestRouter that this ReloadingRequestRouter wraps */
   className: String,
   /* Java/Scala Package Prefixes that are allowed to be reloaded */
   reloadablePackages: Seq[String],
   /* The parent ClassLoader to use */
-  parent: ClassLoader = classOf[ReloadingRequestRouter].getClassLoader,
+  parent: ClassLoader,
   /* Show debugging output */
-  debug: Boolean = false
+  debug: Boolean
 ) extends RequestRouter with Logging {
   
   private[this] val reloadingClassLoader: ReloadingClassLoaderHolder = new ReloadingClassLoaderHolder(reloadablePackages, parent, debug)

--- a/src/test/scala/fm/http/TestClientAndServer.scala
+++ b/src/test/scala/fm/http/TestClientAndServer.scala
@@ -58,9 +58,9 @@ object TestClientAndServer {
   def startServer(): Unit = server
   def stopServer(): Unit = server.shutdown()
 
-  private val options: HttpServerOptions = HttpServerOptions(
-    requestIdResponseHeader = Some("X-Request-Id"),
-    clientIPLookupSpecs = Seq(
+  private val options: HttpServerOptions = HttpServerOptions.default
+    .withRequestIdResponseHeader(Some("X-Request-Id"))
+    .withClientIPLookupSpecs(Seq(
       HttpServerOptions.ClientIPLookupSpec(
         headerName = "X-Client-IP",
         requiredHeaderAndValue = Some(("X-Is-From-CDN", "abc123")),
@@ -97,8 +97,7 @@ object TestClientAndServer {
         requiredHeaderAndValue = None,
         valueToUse = HttpServerOptions.ClientIPHeaderValueToUse.OffsetFromLast(2)
       )
-    )
-  )
+    ))
   
   private lazy val server: HttpServer = HttpServer(port, router, "ABC123", options)
   
@@ -210,8 +209,10 @@ object TestClientAndServer {
     
     b.result()
   }
-  
-  protected def makeLinkedHttpContent(sizeBytes: Long, idx: Long = 0): LinkedHttpContent = {
+
+  protected def makeLinkedHttpContent(sizeBytes: Long): LinkedHttpContent = makeLinkedHttpContent(sizeBytes, 0)
+
+  protected def makeLinkedHttpContent(sizeBytes: Long, idx: Long): LinkedHttpContent = {
     if (sizeBytes <= 0) return LinkedHttpContent(Unpooled.EMPTY_BUFFER)
     
     val sizeToGenerate: Int = math.min(sizeBytes, BodyChunkSize).toInt
@@ -258,13 +259,26 @@ final class TestClientAndServer extends FunSuite with Matchers with BeforeAndAft
     require(path.startsWith("/"), "Path must start with a slash: "+path)
     s"http://127.0.0.1:${TestClientAndServer.port}"+path
   }
-  
+
+  private def getSync(
+    path: String,
+    expectedCode: Int,
+    expectedBody: String
+  ): FullStringResponse = getSync(path, expectedCode, expectedBody, client)
+
   private def getSync(
     path: String,
     expectedCode: Int,
     expectedBody: String,
-    httpClient: HttpClient = client,
-    headers: Headers = Headers.empty
+    httpClient: HttpClient,
+  ): FullStringResponse = getSync(path, expectedCode, expectedBody, httpClient, Headers.empty)
+
+  private def getSync(
+    path: String,
+    expectedCode: Int,
+    expectedBody: String,
+    httpClient: HttpClient,
+    headers: Headers,
   ): FullStringResponse = TestHelpers.withCallerInfo{
     val f: Future[FullStringResponse] = getFullStringAsync(path, httpClient, headers)
     val res: FullStringResponse = Await.result(f, 10.seconds)
@@ -277,8 +291,15 @@ final class TestClientAndServer extends FunSuite with Matchers with BeforeAndAft
     path: String,
     postBody: String,
     expectedCode: Int,
+    expectedBody: String
+  ): Unit = postSync(path, postBody, expectedCode, expectedBody, client)
+
+  private def postSync(
+    path: String,
+    postBody: String,
+    expectedCode: Int,
     expectedBody: String,
-    httpClient: HttpClient = client
+    httpClient: HttpClient
   ): Unit = TestHelpers.withCallerInfo{
     val f: Future[FullStringResponse] = postFullStringAsync(path, postBody, httpClient)
     val res: FullStringResponse = Await.result(f, 10.seconds)
@@ -297,7 +318,12 @@ final class TestClientAndServer extends FunSuite with Matchers with BeforeAndAft
   private def postFullStringAsync(
     path: String,
     postBody: String,
-    httpClient: HttpClient = client
+  ): Future[FullStringResponse] = postFullStringAsync(path, postBody, client)
+
+  private def postFullStringAsync(
+    path: String,
+    postBody: String,
+    httpClient: HttpClient,
   ): Future[FullStringResponse] = {
     httpClient.postFullString(makeUrl(path), postBody)
   }
@@ -622,6 +648,6 @@ final class TestClientAndServer extends FunSuite with Matchers with BeforeAndAft
   }
 
   private def checkIp(expected: String, headers: (String,String)*): Unit = TestHelpers.withCallerInfo{
-    getSync("/ip", 200, expected, headers = Headers(headers:_*))
+    getSync("/ip", 200, expected, client, headers = Headers(headers:_*))
   }
 }


### PR DESCRIPTION
Doesn't touch `Cookie`, `MutableHeaders`, or `HttpClient` since their use of default parameters is so prevalent.

# sbt test

```
[info] Run completed in 34 seconds, 476 milliseconds.
[info] Total number of tests run: 60
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 60, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

# ta-catalog

```
[info] Done compiling.
[success] Total time: 495 s, completed Nov 14, 2019, 10:24:36 AM
```

# ta-webservice-api

```
[info] Done compiling.
[success] Total time: 285 s, completed Nov 14, 2019, 10:33:36 AM
```

