### PR TITLE
LinkedHttpContentReader Read Limits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
   "com.frugalmechanic" %% "fm-lazyseq" % "0.10.0" % "test"
 )
 
-val nettyVersion: String = "4.1.30.Final"
+val nettyVersion: String = "4.1.31.Final"
 
 libraryDependencies ++= Seq(
   "io.netty" % "netty-all" % nettyVersion,

--- a/src/main/scala/fm/http/LinkedHttpContentReader.scala
+++ b/src/main/scala/fm/http/LinkedHttpContentReader.scala
@@ -15,30 +15,56 @@
  */
 package fm.http
 
-import fm.common.{IOUtils, Logging}
+import fm.common.{IOUtils, Logging, StacklessException}
+import fm.common.Implicits._
 import io.netty.buffer.{ByteBuf, Unpooled}
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.{DefaultFullHttpResponse, FullHttpResponse, HttpResponseStatus, HttpVersion}
 import io.netty.util.CharsetUtil
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, Closeable, File, FileOutputStream}
 import java.nio.charset.Charset
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success, Try}
 
-object LinkedHttpContentReader {
-  def apply(need100Continue: Boolean, head: Future[Option[LinkedHttpContent]])(implicit ctx: ChannelHandlerContext, executor: ExecutionContext): LinkedHttpContentReader = new LinkedHttpContentReader(need100Continue, head)
+object LinkedHttpContentReader extends Logging {
+  def apply(need100Continue: Boolean, contentLength: Option[Long], head: Future[Option[LinkedHttpContent]])(implicit ctx: ChannelHandlerContext, executor: ExecutionContext): LinkedHttpContentReader = new LinkedHttpContentReader(need100Continue, contentLength, head)
 
   def empty(implicit executor: ExecutionContext): LinkedHttpContentReader = {
     val ctx: ChannelHandlerContext = null
-    LinkedHttpContentReader(false, Future.successful(None))(ctx, executor)
+    LinkedHttpContentReader(false, None, Future.successful(None))(ctx, executor)
+  }
+
+  sealed trait MaxLengthStrategy {
+    def checkMaxLengthAfterRead(currentLength: Long, maxLength: Long): Unit = {
+      if ((this === MaxLengthStrategy.CloseConnection) && currentLength > maxLength) throw new MaxLengthException(s"Body exceeds maxLength.  Body Length (so far): $currentLength  Specified Max Length: $maxLength")
+    }
+
+    // This is just an alias of checkMaxLengthOnComplete, but helpful for reading the code.
+    def checkMaxLengthFromContentLength(contentLength: Long, maxLength: Long): Unit = checkMaxLengthAfterAllContentRead(contentLength, maxLength)
+
+    def checkMaxLengthAfterAllContentRead(bodyLength: Long, maxLength: Long): Unit = {
+      if ((this === MaxLengthStrategy.DiscardAndThrowException) &&  bodyLength > maxLength) throw new MaxLengthException(s"Body exceeds maxLength. Body Length: $bodyLength  Specified Max Length: $maxLength")
+    }
+  }
+
+  case class MaxLengthException(msg: String) extends StacklessException(msg)
+
+  object MaxLengthStrategy {
+    // Throws an exception immediately when limit reached
+    case object CloseConnection          extends MaxLengthStrategy
+    // No exception, but response is truncated to the limit
+    case object Truncate                 extends MaxLengthStrategy
+    // Reads the entire linked reader but starts discarding content after the max limit, and then throws exception after fully read.
+    case object DiscardAndThrowException extends MaxLengthStrategy
   }
 
   private val CONTINUE: FullHttpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE, Unpooled.EMPTY_BUFFER)  
 }
 
-final class LinkedHttpContentReader(is100ContinueExpected: Boolean, head: Future[Option[LinkedHttpContent]])(implicit ctx: ChannelHandlerContext, executor: ExecutionContext) extends Closeable with Logging {
+final class LinkedHttpContentReader(is100ContinueExpected: Boolean, contentLength: Option[Long], head: Future[Option[LinkedHttpContent]])(implicit ctx: ChannelHandlerContext, executor: ExecutionContext) extends Closeable with Logging {
   import LinkedHttpContentReader.CONTINUE
+  import LinkedHttpContentReader.MaxLengthStrategy
 
   private[this] val foldLeftCalled: AtomicBoolean = new AtomicBoolean(false)
   private[this] val hasBeenFullyRead: AtomicBoolean = new AtomicBoolean(false)
@@ -69,36 +95,53 @@ final class LinkedHttpContentReader(is100ContinueExpected: Boolean, head: Future
    * This will be completed when the body is fully read (or an exception is thrown)
    */
   def future: Future[Unit] = completedPromise.future
-  
+
   /**
    * Read the response body into an Array[Byte]
    */
   def readToByteArray(): Future[Array[Byte]] = readToByteArray(Long.MaxValue)
+  def readToByteArray(maxLength: Long): Future[Array[Byte]] = readToByteArray(maxLength, MaxLengthStrategy.CloseConnection)
+  
+  def readToByteArray(maxLength: Long, maxLengthStrategy: MaxLengthStrategy): Future[Array[Byte]] = {
+    contentLength.foreach{ maxLengthStrategy.checkMaxLengthFromContentLength(_, maxLength) }
 
-  def readToByteArray(maxLength: Long): Future[Array[Byte]] = {
+    val bytesRead: AtomicLong = new AtomicLong(0)
+
     foldLeft(new ByteArrayOutputStream){ (out: ByteArrayOutputStream, buf: ByteBuf) =>
+      val readableBytes: Int = buf.readableBytes
+      bytesRead.addAndGet(readableBytes)
       buf.readBytes(out, buf.readableBytes())
-      require(out.size() <= maxLength, s"Body exceeds maxLength.  Body Length (so far): ${out.size}  Specified Max Length: $maxLength")
+      maxLengthStrategy.checkMaxLengthAfterRead(out.size, maxLength)
+
       out
+    }.filter { _ =>
+      maxLengthStrategy.checkMaxLengthAfterAllContentRead(bytesRead.get, maxLength)
+
+      true
     }.map{ _.toByteArray }
   }
   
   /**
    * Read the response body into a string
    */
+  def readToString(maxLength: Long): Future[String] = readToString(maxLength, CharsetUtil.ISO_8859_1, MaxLengthStrategy.CloseConnection)
+  def readToString(maxLength: Long, maxLengthStrategy: MaxLengthStrategy): Future[String] = readToString(maxLength, CharsetUtil.ISO_8859_1, maxLengthStrategy)
+    
+  def readToString(encoding: Charset): Future[String] = readToString(Long.MaxValue, encoding, MaxLengthStrategy.CloseConnection)
 
-  def readToString(maxLength: Long): Future[String] = readToString(maxLength, CharsetUtil.ISO_8859_1)
-  def readToString(encoding: Charset): Future[String] = readToString(Long.MaxValue, CharsetUtil.ISO_8859_1)
+  def readToString(maxLength: Long, encoding: Charset): Future[String] = readToString(maxLength, encoding, MaxLengthStrategy.CloseConnection)
 
-  def readToString(maxLength: Long, encoding: Charset): Future[String] = {
-    if (null == encoding) readToStringWithDetectedCharset(maxLength) else readToStringWithCharset(encoding, maxLength)
+  def readToString(maxLength: Long, encoding: Charset, maxLengthStrategy: MaxLengthStrategy): Future[String] = {
+    if (null == encoding) readToStringWithDetectedCharset(maxLength, maxLengthStrategy) else readToStringWithCharset(encoding, maxLength, maxLengthStrategy)
   }
 
+  def readToStringWithDetectedCharset(): Future[String] = readToStringWithDetectedCharset(Long.MaxValue)
   def readToStringWithDetectedCharset(maxLength: Long): Future[String] = readToStringWithDetectedCharset(maxLength, CharsetUtil.ISO_8859_1)
-  def readToStringWithDetectedCharset(defaultEncoding: Charset): Future[String] = readToStringWithDetectedCharset(Long.MaxValue, CharsetUtil.ISO_8859_1)
+  def readToStringWithDetectedCharset(maxLength: Long, maxLengthStrategy: MaxLengthStrategy): Future[String] = readToStringWithDetectedCharset(maxLength, CharsetUtil.ISO_8859_1, maxLengthStrategy)
+  def readToStringWithDetectedCharset(maxLength: Long, defaultEncoding: Charset): Future[String] = readToStringWithDetectedCharset(maxLength, defaultEncoding, MaxLengthStrategy.CloseConnection)
 
-  def readToStringWithDetectedCharset(maxLength: Long, defaultEncoding: Charset): Future[String] = {
-    readToByteArray(maxLength).map{ bytes: Array[Byte] =>
+  def readToStringWithDetectedCharset(maxLength: Long, defaultEncoding: Charset, maxLengthStrategy: MaxLengthStrategy): Future[String] = {
+    readToByteArray(maxLength, maxLengthStrategy).map{ bytes: Array[Byte] =>
       val charset: Option[Charset] = IOUtils.detectCharset(new ByteArrayInputStream(bytes), false)
       
       // The default charset for text should be Latin-1 according to http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7.1
@@ -107,28 +150,59 @@ final class LinkedHttpContentReader(is100ContinueExpected: Boolean, head: Future
   }
 
   def readToStringWithCharset(encoding: Charset): Future[String] = readToStringWithCharset(encoding, Long.MaxValue)
+  def readToStringWithCharset(encoding: Charset, maxLength: Long): Future[String] = readToStringWithCharset(encoding, maxLength, MaxLengthStrategy.CloseConnection)
 
-  def readToStringWithCharset(encoding: Charset, maxLength: Long): Future[String] = {
+  def readToStringWithCharset(encoding: Charset, maxLength: Long, maxLengthStrategy: MaxLengthStrategy): Future[String] = {
+    contentLength.foreach{ maxLengthStrategy.checkMaxLengthFromContentLength(_, maxLength) }
+
     foldLeft(new StringBuilder){ (sb: StringBuilder, buf: ByteBuf) =>
-      sb.append(buf.toString(encoding))
-      require(sb.length <= maxLength, s"Body exceeds maxLength.  Body Length (so far): ${sb.length}  Specified Max Length: $maxLength")
+      if (sb.length <= maxLength) sb.append(buf.toString(encoding))
+      else buf.discardReadBytes()
+
+
+      maxLengthStrategy.checkMaxLengthAfterRead(sb.length, maxLength)
+
       sb
+    }.filter{ sb: StringBuilder =>
+      maxLengthStrategy.checkMaxLengthAfterAllContentRead(sb.length, maxLength)
+      true
     }.map{ _.toString }
   }
-  
+
   /**
    * Write this body to a file
    */
-  def writeToFile(file: File): Future[Unit] = {
+  def writeToFile(file: File): Future[Unit] = writeToFile(file, Long.MaxValue, MaxLengthStrategy.CloseConnection)
+
+  def writeToFile(file: File, maxLength: Long, maxLengthStrategy: MaxLengthStrategy): Future[Unit] = {
+    import java.util.concurrent.atomic.AtomicLong
+    contentLength.foreach{ maxLengthStrategy.checkMaxLengthFromContentLength(_, maxLength) }
+
     val os: FileOutputStream = new FileOutputStream(file)
-    val f: Future[Unit] = foldLeft(os){ (os, buf) =>
-      buf.readBytes(os, buf.readableBytes())
-      os
-    }.map{ _ => Unit }
+    val bytesRead: AtomicLong = new AtomicLong(0)
+
+    val f: Future[Unit] = {
+      foldLeft(os){ (os, buf) =>
+        val readableBytes: Int = buf.readableBytes
+        bytesRead.addAndGet(readableBytes)
+
+        maxLengthStrategy.checkMaxLengthAfterRead(bytesRead.get, maxLength)
+        if (bytesRead.get <= maxLength) buf.readBytes(os, readableBytes)
+        else buf.discardReadBytes()
+
+        os
+      }.map{ _ => Unit }
+    }
     
-    f.onComplete{ case _ => os.close() }
-    
-    f
+    f.onComplete{ case _ =>
+      os.close()
+    }
+
+    f.filter{ _: Unit =>
+      maxLengthStrategy.checkMaxLengthAfterAllContentRead(bytesRead.get, maxLength)
+
+      true
+    }
   }
   
   /**
@@ -148,7 +222,7 @@ final class LinkedHttpContentReader(is100ContinueExpected: Boolean, head: Future
     require(null != current, "current == null which means the data was already read!")
     
     val p: Promise[B] = Promise()
-    
+
     if (is100ContinueExpected) ctx.writeAndFlush(CONTINUE)
     
     foldLeft0(current)(z, op, p)

--- a/src/main/scala/fm/http/PostData.scala
+++ b/src/main/scala/fm/http/PostData.scala
@@ -49,7 +49,9 @@ sealed trait PostData {
   final def length: Long = self.length()
   
   /** The InputStreamResource for reading this data */
-  def inputStreamResource(autoDecompress: Boolean = true, autoBuffer: Boolean = true): InputStreamResource
+  final def inputStreamResource(): InputStreamResource = inputStreamResource(true, true)
+  final def inputStreamResource(autoDecompress: Boolean): InputStreamResource = inputStreamResource(autoDecompress, true)
+  def inputStreamResource(autoDecompress: Boolean, autoBuffer: Boolean): InputStreamResource
 
   final def value: String = self.getString()
   
@@ -60,7 +62,7 @@ sealed trait PostData {
 sealed trait MemoryPostData extends PostData {
   protected final def resource: Resource[InputStream] = MultiUseResource{ new ByteBufInputStream(self.getByteBuf) }
   
-  final def inputStreamResource(autoDecompress: Boolean = true, autoBuffer: Boolean = true): InputStreamResource = InputStreamResource(resource, autoDecompress = autoDecompress, autoBuffer = autoBuffer)
+  final def inputStreamResource(autoDecompress: Boolean, autoBuffer: Boolean): InputStreamResource = InputStreamResource(resource, autoDecompress = autoDecompress, autoBuffer = autoBuffer)
 }
 
 sealed trait DiskPostData extends PostData {  
@@ -86,7 +88,7 @@ final case class MemoryPostAttribute(protected val self: netty.Attribute) extend
 final case class DiskPostAttribute(protected val self: netty.Attribute) extends PostAttribute with DiskPostData {
   require(!self.isInMemory, "Can't use an isInMemory=true instance of DiskAttribute with DiskPostAttribute")
   
-  def inputStreamResource(autoDecompress: Boolean = true, autoBuffer: Boolean = true): InputStreamResource = {
+  def inputStreamResource(autoDecompress: Boolean, autoBuffer: Boolean): InputStreamResource = {
     InputStreamResource.forFile(file, autoDecompress = autoDecompress, autoBuffer = autoBuffer)
   }
 }
@@ -98,7 +100,7 @@ final case class MemoryFileUpload(protected val self: netty.FileUpload) extends 
 final case class DiskFileUpload(protected val self: netty.FileUpload) extends FileUpload with DiskPostData {
   require(!self.isInMemory, "Can't use an isInMemory=true instance of FileUpload with DiskFileUpload")
   
-  def inputStreamResource(autoDecompress: Boolean = true, autoBuffer: Boolean = true): InputStreamResource = {
+  def inputStreamResource(autoDecompress: Boolean, autoBuffer: Boolean): InputStreamResource = {
     InputStreamResource.forFile(file, fileName.getOrElse(""), autoDecompress = autoDecompress, autoBuffer = autoBuffer)
   }
 }

--- a/src/main/scala/fm/http/Status.scala
+++ b/src/main/scala/fm/http/Status.scala
@@ -39,7 +39,9 @@ final class Status private (netty: HttpResponseStatus) {
     case HttpResponseStatus.TEMPORARY_REDIRECT => true // 307
     case _ => false
   }
-  
+
+  override def toString(): String = s"fm.http.Status($code)"
+
   def toHttpResponseStatus: HttpResponseStatus = netty
   
   override def hashCode: Int = netty.hashCode()

--- a/src/main/scala/fm/http/client/DefaultHttpClient.scala
+++ b/src/main/scala/fm/http/client/DefaultHttpClient.scala
@@ -130,10 +130,39 @@ object DefaultHttpClient extends Logging {
       
     }
   }
+
+  @deprecated("proxy is now a required constructor parameter", "0.25.0") def apply(
+    defaultMaxLength: Long,
+    defaultHeaders: Headers,
+    useConnectionPool: Boolean,  // Should we re-use connections? (Use HTTP Keep Alive?)
+    maxConnectionsPerHost: Int,  // Only applies if useConnectionPool is true
+    maxRequestQueuePerHost: Int, // Only applies if useConnectionPool is true
+    maxConnectionIdleDuration: FiniteDuration,
+    defaultResponseTimeout: Duration, // The maximum time to wait for a Response
+    defaultConnectTimeout: Duration, // The maximum time to wait to connect to a server
+    defaultCharset: Charset, // The default charset to use (if none is specified in the response) when converting responses to strings
+    followRedirects: Boolean, // Should 301/302 redirects be followed for GET or HEAD requests?
+    maxRedirectCount: Int, // The maximum number of 301/302 redirects to follow for a GET or HEAD request
+    disableSSLCertVerification: Boolean // Do not verify SSL certs (SHOULD NOT USE IN PRODUCTION)
+  ): DefaultHttpClient = DefaultHttpClient(
+    None,
+    defaultMaxLength,
+    defaultHeaders,
+    useConnectionPool,
+    maxConnectionsPerHost,
+    maxRequestQueuePerHost,
+    maxConnectionIdleDuration,
+    defaultResponseTimeout,
+    defaultConnectTimeout,
+    defaultCharset,
+    followRedirects,
+    maxRedirectCount,
+    disableSSLCertVerification,
+  )
 }
 
 final case class DefaultHttpClient(
-  proxy: Option[ProxyOptions] = None,
+  proxy: Option[ProxyOptions],
   defaultMaxLength: Long,
   defaultHeaders: Headers,
   useConnectionPool: Boolean,  // Should we re-use connections? (Use HTTP Keep Alive?)

--- a/src/main/scala/fm/http/client/NettyHttpClientPipelineHandler.scala
+++ b/src/main/scala/fm/http/client/NettyHttpClientPipelineHandler.scala
@@ -145,7 +145,7 @@ final class NettyHttpClientPipelineHandler(channelGroup: ChannelGroup, execution
   private def channelReadHttpResponse(nettyResponse: HttpResponse, content: Future[Option[LinkedHttpContent]])(implicit ctx: ChannelHandlerContext): Unit = {
     require(null ne responsePromise, "No promise to receive the HttpResponse")
     
-    val contentReader: LinkedHttpContentReader = LinkedHttpContentReader(need100Continue = false, content)
+    val contentReader: LinkedHttpContentReader = LinkedHttpContentReader(need100Continue = false, head = content)
     
     val response: AsyncResponse = new AsyncResponse(nettyResponse, contentReader)
     
@@ -301,8 +301,10 @@ final class NettyHttpClientPipelineHandler(channelGroup: ChannelGroup, execution
     failPromises(cause)(ctx)
     ctx.close()
   }
-  
-  private def trace(name: String, ex: Throwable = null)(implicit ctx: ChannelHandlerContext): Unit = {
+
+  private def trace(name: String)(implicit ctx: ChannelHandlerContext): Unit = trace(name, null)
+
+  private def trace(name: String, ex: Throwable)(implicit ctx: ChannelHandlerContext): Unit = {
     if (logger.isTraceEnabled) logger.trace(s"$id - $name - ${ctx.channel}", ex)
   }
 }

--- a/src/main/scala/fm/http/client/Request.scala
+++ b/src/main/scala/fm/http/client/Request.scala
@@ -82,7 +82,9 @@ trait FullRequest extends Request with FullMessage {
     initHeaders(new DefaultFullHttpRequest(version, method, uri, buf))
   }
 
-  def withHeaders(newHeaders: Headers): FullRequest
+  final def toHttpRequest(version: HttpVersion, uri: String): HttpRequest = {
+    initHeaders(new DefaultHttpRequest(version, method, uri))
+  }
 }
 
 /**

--- a/src/main/scala/fm/http/client/Request.scala
+++ b/src/main/scala/fm/http/client/Request.scala
@@ -62,32 +62,75 @@ sealed trait Request {
 /**
  * This represents a full HTTP Request (both headers and complete body)
  */
-final case class FullRequest(method: HttpMethod, url: URL, headers: Headers = Headers.empty, buf: ByteBuf = Unpooled.EMPTY_BUFFER) extends Request with FullMessage {
-  def toFullHttpRequest(version: HttpVersion, uri: String): FullHttpRequest = {
+object FullRequest {
+  def apply(method: HttpMethod, url: URL): FullRequest = apply(method, url, Headers.empty)
+  def apply(method: HttpMethod, url: URL, headers: Headers): FullRequest = apply(method, url, headers, Unpooled.EMPTY_BUFFER)
+  def apply(method: HttpMethod, url: URL, headers: Headers, buf: ByteBuf): FullRequest = impl(method, url, headers, buf)
+
+  private case class impl(method: HttpMethod, url: URL, headers: Headers, buf: ByteBuf) extends FullRequest {
+    def withHeaders(newHeaders: Headers): FullRequest = copy(headers = newHeaders)
+  }
+}
+
+trait FullRequest extends Request with FullMessage {
+  def method: HttpMethod
+  def url: URL
+  def headers: Headers
+  def buf: ByteBuf
+
+  final def toFullHttpRequest(version: HttpVersion, uri: String): FullHttpRequest = {
     initHeaders(new DefaultFullHttpRequest(version, method, uri, buf))
   }
-  
-  def withHeaders(newHeaders: Headers): FullRequest = copy(headers = newHeaders)
+
+  def withHeaders(newHeaders: Headers): FullRequest
 }
 
 /**
  * This represents a chunked HTTP Request with headers and the first chunk along with a pointer to the next chunk
  */
-final case class AsyncRequest(method: HttpMethod, url: URL, headers: Headers, head: LinkedHttpContent) extends Request with AsyncMessage {
-  def toHttpRequest(version: HttpVersion, uri: String): HttpRequest = {
+object AsyncRequest {
+  def apply(method: HttpMethod, url: URL): AsyncRequest = apply(method, url, Headers.empty)
+  def apply(method: HttpMethod, url: URL, headers: Headers): AsyncRequest = apply(method, url, headers, LinkedHttpContent(Unpooled.EMPTY_BUFFER))
+  def apply(method: HttpMethod, url: URL, headers: Headers, head: LinkedHttpContent): AsyncRequest = impl(method, url, headers, head)
+
+  private case class impl(method: HttpMethod, url: URL, headers: Headers, head: LinkedHttpContent) extends AsyncRequest {
+    def withHeaders(newHeaders: Headers): AsyncRequest = copy(headers = newHeaders)
+  }
+}
+trait AsyncRequest extends Request with AsyncMessage {
+  def method: HttpMethod
+  def url: URL
+  def headers: Headers
+  def head: LinkedHttpContent
+
+  final def toHttpRequest(version: HttpVersion, uri: String): HttpRequest = {
     initHeaders(new DefaultHttpRequest(version, method, uri))
   }
-  
-  def withHeaders(newHeaders: Headers): AsyncRequest = copy(headers = newHeaders)
+
+  def withHeaders(newHeaders: Headers): AsyncRequest
 }
 
 /**
  * This represents a File that we want to send as the request body
  */
-final case class FileRequest(method: HttpMethod, url: URL, headers: Headers, file: File) extends Request with FileMessage {
-  def toHttpRequest(version: HttpVersion, uri: String): HttpRequest = {
+object FileRequest {
+  def apply(method: HttpMethod, url: URL, file: File): FileRequest = apply(method, url, Headers.empty, file)
+  def apply(method: HttpMethod, url: URL, headers: Headers, head: File): FileRequest = impl(method, url, headers, head)
+
+  private case class impl(method: HttpMethod, url: URL, headers: Headers, file: File) extends FileRequest {
+    def withHeaders(newHeaders: Headers): FileRequest = copy(headers = newHeaders)
+  }
+}
+
+trait FileRequest extends Request with FileMessage {
+  def method: HttpMethod
+  def url: URL
+  def headers: Headers
+  def file: File
+
+  final def toHttpRequest(version: HttpVersion, uri: String): HttpRequest = {
     initHeaders(new DefaultHttpRequest(version, method, uri))
   }
-  
-  def withHeaders(newHeaders: Headers): FileRequest = copy(headers = newHeaders)
+
+  def withHeaders(newHeaders: Headers): FileRequest
 }

--- a/src/main/scala/fm/http/server/HttpServer.scala
+++ b/src/main/scala/fm/http/server/HttpServer.scala
@@ -55,13 +55,17 @@ object HttpServer {
       case ex: Throwable => logger.error(s"Caught Exception in WebServer ($name) Shutdown Hook: "+ ex)
     }
   }
+
+  def apply(router: RequestRouter, authKey: String): HttpServer = HttpServer(8080, router, authKey)
+  def apply(router: RequestRouter, authKey: String, serverOptions: HttpServerOptions): HttpServer = HttpServer(8080, router, authKey, serverOptions)
+  def apply(port: Int, router: RequestRouter, authKey: String): HttpServer = HttpServer(port, router, authKey, HttpServerOptions.default)
 }
 
 final case class HttpServer (
-  port: Int = 8080,
+  port: Int,
   router: RequestRouter,
   authKey: String,
-  serverOptions: HttpServerOptions = HttpServerOptions.default
+  serverOptions: HttpServerOptions
 ) extends Logging {
   private[this] val name: String = s"WebServer on Port $port"
   private[this] val shutdownHookThread: Thread = new HttpServer.ShutdownHookThread(name, this)

--- a/src/main/scala/fm/http/server/HttpServerApp.scala
+++ b/src/main/scala/fm/http/server/HttpServerApp.scala
@@ -112,37 +112,38 @@ abstract class HttpServerApp extends Logging {
    * Run the Web Server
    */
   private def doRun(ports: Set[Int], detatch: Boolean, emailLogging: Boolean): Unit = {
-    val options: HttpServerOptions = HttpServerOptions(
-      requestIdResponseHeader = requestIdResponseHeader,
-      clientIPLookupSpecs = clientIPLookupSpecs
-    )
+    val options: HttpServerOptions = {
+      HttpServerOptions.default
+        .withRequestIdResponseHeader(requestIdResponseHeader)
+        .withClientIPLookupSpecs(clientIPLookupSpecs)
+    }
 
-    // Figure out which port we should listen on    
+    // Figure out which port we should listen on
     val (usedPorts, availPorts) = ports.partition{ alive }
-    
+
     if (availPorts.isEmpty) { logger.error("All Ports in use"); sys.exit(-1) }
-    
+
     val port: Int = availPorts.head
     logger.info("Using Port: "+port)
-    
+
     // Startup the Server
     val server: HttpServer = HttpServer(port, router, AuthKey, options)
-    
+
     // Check that the server is alive and responding
     assert(alive(port), "Server not alive?!")
-    
+
     server.enablePing()
 
     registerPingSignalHandlers(server)
-    
+
     if (usedPorts.nonEmpty) {
       logger.info("Allowing Load Balancer to pickup new server...")
       Thread.sleep(5000)
-      
+
       logger.info("Shutting down old servers...")
       shutdownPorts(usedPorts)
     }
-    
+
     if (emailLogging) setupEmailLogging()
 
     logger.info("Successfully Started ("+POSIX.getpid+")")
@@ -150,21 +151,21 @@ abstract class HttpServerApp extends Logging {
     if (detatch) {
       logger.info("Redirecting STDOUT/STDERR to log and Detatching...")
       println(DETATCH_STRING)
-      
+
       POSIX.setsid()
 
       System.out.close()
       System.err.close()
 
       removeConsoleLogging()
-      
+
       System.setOut(new PrintStream(new LoggingOutputStream("stdout"), true, "UTF-8"))
       System.setErr(new PrintStream(new LoggingOutputStream("stderr"), true, "UTF-8"))
     }
 
     // Block until shutdown is requested
     server.awaitShutdown()
-    
+
     // Shutdown Logging
     import ch.qos.logback.classic.LoggerContext
     LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext].stop()
@@ -195,7 +196,9 @@ abstract class HttpServerApp extends Logging {
   /**
    * Create the exec command that will be used to launch the child process
    */
-  private def makeCommand(ports: Set[Int], includeClasspath: Boolean = true): Seq[String] = {
+  private def makeCommand(ports: Set[Int]): Seq[String] = makeCommand(ports, true)
+
+  private def makeCommand(ports: Set[Int], includeClasspath: Boolean): Seq[String] = {
     val JAVA_HOME: String = System.getProperty("java.home")
     
     val JAVA_OPTS: Seq[String] = ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toIndexedSeq ++ Seq(

--- a/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
+++ b/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
@@ -132,9 +132,11 @@ final class NettyHttpServerPipelineHandler(channelGroup: ChannelGroup, execution
     val version: HttpVersion = nettyRequest.protocolVersion()
     
     // TODO: handle HEAD requests where we don't want to send back the body
-    response.recover { case ex: Throwable =>
-      logger.error("Caught Exception waiting for Response Future - Sending Error Response", ex)
-      makeErrorResponse(Status.INTERNAL_SERVER_ERROR)
+    response.recover {
+      case ex: LinkedHttpContentReader.MaxLengthException => Response.plain(Status.REQUEST_ENTITY_TOO_LARGE, "413 Request Entity Too Large")
+      case ex: Throwable =>
+        logger.error("Caught Exception waiting for Response Future - Sending Error Response", ex)
+        makeErrorResponse(Status.INTERNAL_SERVER_ERROR)
     }.foreach { res: Response => res match {
       case full:  FullResponse             => sendFullResponse(request, prepareResponse(request, full.toFullHttpResponse(version), wantKeepAlive))
       case async: AsyncResponse            => sendAsyncResponse(request, prepareResponse(request, async.toHttpResponse(version), wantKeepAlive), async.head)
@@ -161,8 +163,9 @@ final class NettyHttpServerPipelineHandler(channelGroup: ChannelGroup, execution
     val remoteIp: IP = remoteIPForRequest(request)
      
     val is100ContinueExpected: Boolean = HttpUtil.is100ContinueExpected(request)
+    val contentLength: Option[Long] = Try { HttpUtil.getContentLength(request) }.toOption
     
-    val contentReader: LinkedHttpContentReader = LinkedHttpContentReader(is100ContinueExpected, content)
+    val contentReader: LinkedHttpContentReader = LinkedHttpContentReader(is100ContinueExpected, contentLength, content)
     val r: Request = Request(remoteIp, request, contentReader)
     
     val future: Future[Response] = router.lookup(r) match {
@@ -170,6 +173,7 @@ final class NettyHttpServerPipelineHandler(channelGroup: ChannelGroup, execution
         try {
           handler(r)
         } catch {
+          case ex: LinkedHttpContentReader.MaxLengthException => Future.failed(ex)
           case ex: Exception =>
             logger.error(s"Caught exception handling request: request", ex)
             Future.successful(makeErrorResponse(Status.INTERNAL_SERVER_ERROR))

--- a/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
+++ b/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
@@ -444,8 +444,10 @@ final class NettyHttpServerPipelineHandler(channelGroup: ChannelGroup, execution
     if (null != contentBuilder) contentBuilder += cause
     ctx.close()
   }
-  
-  private def trace(name: String, ex: Throwable = null)(implicit ctx: ChannelHandlerContext): Unit = {
+
+  private def trace(name: String)(implicit ctx: ChannelHandlerContext): Unit = trace(name, null)
+
+  private def trace(name: String, ex: Throwable)(implicit ctx: ChannelHandlerContext): Unit = {
     if (logger.isTraceEnabled) logger.trace(s"$id - $name - ${ctx.channel}", ex)
   }
 }

--- a/src/main/scala/fm/http/server/ReloadingRequestRouter.scala
+++ b/src/main/scala/fm/http/server/ReloadingRequestRouter.scala
@@ -8,15 +8,21 @@ import fm.common.Logging
  * 
  * For best results limit the scope of the reloadablePackages.
  */
+
+object ReloadingRequestRouter {
+  def apply(className: String, reloadablePackages: Seq[String]): ReloadingRequestRouter = apply(className, reloadablePackages, classOf[ReloadingRequestRouter].getClassLoader)
+  def apply(className: String, reloadablePackages: Seq[String], parent: ClassLoader): ReloadingRequestRouter = apply(className, reloadablePackages, parent, false)
+}
+
 final case class ReloadingRequestRouter(
   /* The fully qualified className of the RequestRouter that this ReloadingRequestRouter wraps */
   className: String,
   /* Java/Scala Package Prefixes that are allowed to be reloaded */
   reloadablePackages: Seq[String],
   /* The parent ClassLoader to use */
-  parent: ClassLoader = classOf[ReloadingRequestRouter].getClassLoader,
+  parent: ClassLoader,
   /* Show debugging output */
-  debug: Boolean = false
+  debug: Boolean
 ) extends RequestRouter with Logging {
   
   private[this] val reloadingClassLoader: ReloadingClassLoaderHolder = new ReloadingClassLoaderHolder(reloadablePackages, parent, debug)

--- a/src/main/scala/fm/http/server/Response.scala
+++ b/src/main/scala/fm/http/server/Response.scala
@@ -140,6 +140,7 @@ object Response {
   def plain(status: Status): Response = plain(status, Headers.empty)
   def plain(status: Status, headers: Headers): Response = plain(status, s"${status.code} ${status.msg}", headers)
   def plain(status: Status, headers: Headers, body: String): Response = plain(status, body, headers)
+  def plain(status: Status, body: String): Response = FullResponse(status, Headers.empty, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8))
   def plain(status: Status, body: String, headers: Headers): Response = FullResponse(status, headers, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8))
 
   //

--- a/src/main/scala/fm/http/server/Response.scala
+++ b/src/main/scala/fm/http/server/Response.scala
@@ -173,8 +173,20 @@ sealed trait Response extends Message {
 /**
  * This represents a full HTTP Response (both headers and complete body)
  */
-final case class FullResponse(status: Status, headers: Headers = Headers.empty, buf: ByteBuf = Unpooled.EMPTY_BUFFER) extends Response with FullMessage {
-  def toFullHttpResponse(version: HttpVersion): FullHttpResponse = {
+object FullResponse {
+  def apply(status: Status): FullResponse = apply(status, Headers.empty)
+  def apply(status: Status, headers: Headers): FullResponse = apply(status, headers, Unpooled.EMPTY_BUFFER)
+  def apply(status: Status, headers: Headers, buf: ByteBuf): FullResponse = impl(status, headers, buf)
+
+  private case class impl(status: Status, headers: Headers, buf: ByteBuf) extends FullResponse
+}
+
+trait FullResponse extends Response with FullMessage {
+  def status: Status
+  def headers: Headers
+  def buf: ByteBuf
+
+  final def toFullHttpResponse(version: HttpVersion): FullHttpResponse = {
     val r = new DefaultFullHttpResponse(version, status.toHttpResponseStatus, buf)
     r.headers().add(headers.nettyHeaders)
     r
@@ -184,8 +196,20 @@ final case class FullResponse(status: Status, headers: Headers = Headers.empty, 
 /**
  * This represents a chunked HTTP Response with headers and the first chunk along with a pointer to the next chunk
  */
-final case class AsyncResponse(status: Status, headers: Headers, head: LinkedHttpContent) extends Response with AsyncMessage {
-  def toHttpResponse(version: HttpVersion): HttpResponse = {
+object AsyncResponse {
+  def apply(status: Status): AsyncResponse = apply(status, Headers.empty)
+  def apply(status: Status, headers: Headers): AsyncResponse = apply(status, headers, LinkedHttpContent(Unpooled.EMPTY_BUFFER))
+  def apply(status: Status, headers: Headers, head: LinkedHttpContent): AsyncResponse = impl(status, headers, head)
+
+  private case class impl(status: Status, headers: Headers, head: LinkedHttpContent) extends AsyncResponse
+}
+
+trait AsyncResponse extends Response with AsyncMessage {
+  def status: Status
+  def headers: Headers
+  def head: LinkedHttpContent
+
+  final def toHttpResponse(version: HttpVersion): HttpResponse = {
     val r = new DefaultHttpResponse(version, status.toHttpResponseStatus)
     r.headers().add(headers.nettyHeaders)
     r
@@ -195,8 +219,19 @@ final case class AsyncResponse(status: Status, headers: Headers, head: LinkedHtt
 /**
  * This represents a File that we want to send back to the user 
  */
-final case class FileResponse(status: Status, headers: Headers, file: File) extends Response with FileMessage {
-  def toHttpResponse(version: HttpVersion): HttpResponse = {
+object FileResponse {
+  def apply(status: Status, file: File): FileResponse = apply(status, Headers.empty, file)
+  def apply(status: Status, headers: Headers, file: File): FileResponse = impl(status, headers, file)
+
+  private case class impl(status: Status, headers: Headers, file: File) extends FileResponse
+}
+
+trait FileResponse extends Response with FileMessage {
+  def status: Status
+  def headers: Headers
+  def file: File
+
+  final def toHttpResponse(version: HttpVersion): HttpResponse = {
     val r = new DefaultHttpResponse(version, status.toHttpResponseStatus)
     r.headers().add(headers.nettyHeaders)
     r
@@ -206,19 +241,48 @@ final case class FileResponse(status: Status, headers: Headers, file: File) exte
 /**
  * This represents a RandomAccessFile that we want to send back to the user
  */
-final case class RandomAccessFileResponse(status: Status, headers: Headers, file: RandomAccessFile) extends Response {
-  def toHttpResponse(version: HttpVersion): HttpResponse = {
+
+object RandomAccessFileResponse {
+  def apply(status: Status, file: RandomAccessFile): RandomAccessFileResponse = apply(status, Headers.empty, file)
+  def apply(status: Status, file: RandomAccessFile, headers: Headers): RandomAccessFileResponse = apply(status, headers, file)
+  def apply(status: Status, headers: Headers, file: RandomAccessFile): RandomAccessFileResponse = impl(status, headers, file)
+
+  private case class impl(status: Status, headers: Headers, file: RandomAccessFile) extends RandomAccessFileResponse
+}
+
+trait RandomAccessFileResponse extends Response {
+  def status: Status
+  def headers: Headers
+  def file: RandomAccessFile
+
+  final def toHttpResponse(version: HttpVersion): HttpResponse = {
     val r = new DefaultHttpResponse(version, status.toHttpResponseStatus)
     r.headers().add(headers.nettyHeaders)
     r
   }
 }
 
+
 /**
  * This represents an InputStream that we want to send back to the user 
  */
-final case class InputStreamResponse(status: Status, headers: Headers, input: InputStream, length: Option[Long]) extends Response with InputStreamMessage {
-  def toHttpResponse(version: HttpVersion): HttpResponse = {
+
+object InputStreamResponse {
+  def apply(status: Status, input: InputStream): InputStreamResponse = apply(status, Headers.empty, input, None)
+  def apply(status: Status, input: InputStream, length: Option[Long]): InputStreamResponse = apply(status, Headers.empty, input, length)
+  def apply(status: Status, headers: Headers, input: InputStream): InputStreamResponse = apply(status, headers, input, None)
+  def apply(status: Status, headers: Headers, input: InputStream, length: Option[Long]): InputStreamResponse = impl(status, headers, input, length)
+
+  private case class impl(status: Status, headers: Headers, input: InputStream, length: Option[Long]) extends InputStreamResponse
+}
+
+trait InputStreamResponse extends Response with InputStreamMessage {
+  def status: Status
+  def headers: Headers
+  def input: InputStream
+  def length: Option[Long]
+
+  final def toHttpResponse(version: HttpVersion): HttpResponse = {
     val r = new DefaultHttpResponse(version, status.toHttpResponseStatus)
     r.headers().add(headers.nettyHeaders)
     r

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <!--<encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">-->
+    <encoder class="fm.common.ColorPatternLayoutEncoder">
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${LOGBACK_LEVEL:-warn}">
+    <appender-ref ref="STDERR" />
+  </root>
+</configuration>

--- a/src/test/scala/fm/http/TestClientAndServer.scala
+++ b/src/test/scala/fm/http/TestClientAndServer.scala
@@ -58,9 +58,9 @@ object TestClientAndServer {
   def startServer(): Unit = server
   def stopServer(): Unit = server.shutdown()
 
-  private val options: HttpServerOptions = HttpServerOptions(
-    requestIdResponseHeader = Some("X-Request-Id"),
-    clientIPLookupSpecs = Seq(
+  private val options: HttpServerOptions = HttpServerOptions.default
+    .withRequestIdResponseHeader(Some("X-Request-Id"))
+    .withClientIPLookupSpecs(Seq(
       HttpServerOptions.ClientIPLookupSpec(
         headerName = "X-Client-IP",
         requiredHeaderAndValue = Some(("X-Is-From-CDN", "abc123")),
@@ -97,8 +97,7 @@ object TestClientAndServer {
         requiredHeaderAndValue = None,
         valueToUse = HttpServerOptions.ClientIPHeaderValueToUse.OffsetFromLast(2)
       )
-    )
-  )
+    ))
   
   private lazy val server: HttpServer = HttpServer(port, router, "ABC123", options)
   
@@ -210,8 +209,10 @@ object TestClientAndServer {
     
     b.result()
   }
-  
-  protected def makeLinkedHttpContent(sizeBytes: Long, idx: Long = 0): LinkedHttpContent = {
+
+  protected def makeLinkedHttpContent(sizeBytes: Long): LinkedHttpContent = makeLinkedHttpContent(sizeBytes, 0)
+
+  protected def makeLinkedHttpContent(sizeBytes: Long, idx: Long): LinkedHttpContent = {
     if (sizeBytes <= 0) return LinkedHttpContent(Unpooled.EMPTY_BUFFER)
     
     val sizeToGenerate: Int = math.min(sizeBytes, BodyChunkSize).toInt
@@ -258,13 +259,26 @@ final class TestClientAndServer extends FunSuite with Matchers with BeforeAndAft
     require(path.startsWith("/"), "Path must start with a slash: "+path)
     s"http://127.0.0.1:${TestClientAndServer.port}"+path
   }
-  
+
+  private def getSync(
+    path: String,
+    expectedCode: Int,
+    expectedBody: String
+  ): FullStringResponse = getSync(path, expectedCode, expectedBody, client)
+
   private def getSync(
     path: String,
     expectedCode: Int,
     expectedBody: String,
-    httpClient: HttpClient = client,
-    headers: Headers = Headers.empty
+    httpClient: HttpClient,
+  ): FullStringResponse = getSync(path, expectedCode, expectedBody, httpClient, Headers.empty)
+
+  private def getSync(
+    path: String,
+    expectedCode: Int,
+    expectedBody: String,
+    httpClient: HttpClient,
+    headers: Headers,
   ): FullStringResponse = TestHelpers.withCallerInfo{
     val f: Future[FullStringResponse] = getFullStringAsync(path, httpClient, headers)
     val res: FullStringResponse = Await.result(f, 10.seconds)
@@ -277,8 +291,15 @@ final class TestClientAndServer extends FunSuite with Matchers with BeforeAndAft
     path: String,
     postBody: String,
     expectedCode: Int,
+    expectedBody: String
+  ): Unit = postSync(path, postBody, expectedCode, expectedBody, client)
+
+  private def postSync(
+    path: String,
+    postBody: String,
+    expectedCode: Int,
     expectedBody: String,
-    httpClient: HttpClient = client
+    httpClient: HttpClient
   ): Unit = TestHelpers.withCallerInfo{
     val f: Future[FullStringResponse] = postFullStringAsync(path, postBody, httpClient)
     val res: FullStringResponse = Await.result(f, 10.seconds)
@@ -297,7 +318,12 @@ final class TestClientAndServer extends FunSuite with Matchers with BeforeAndAft
   private def postFullStringAsync(
     path: String,
     postBody: String,
-    httpClient: HttpClient = client
+  ): Future[FullStringResponse] = postFullStringAsync(path, postBody, client)
+
+  private def postFullStringAsync(
+    path: String,
+    postBody: String,
+    httpClient: HttpClient,
   ): Future[FullStringResponse] = {
     httpClient.postFullString(makeUrl(path), postBody)
   }
@@ -622,6 +648,6 @@ final class TestClientAndServer extends FunSuite with Matchers with BeforeAndAft
   }
 
   private def checkIp(expected: String, headers: (String,String)*): Unit = TestHelpers.withCallerInfo{
-    getSync("/ip", 200, expected, headers = Headers(headers:_*))
+    getSync("/ip", 200, expected, client, headers = Headers(headers:_*))
   }
 }


### PR DESCRIPTION
This is a preview PR, but largely done - I might add another test or two, and then I need to go through the PR with a finer grain comb. 

It adds additional support for `maxLength` limits in `LinkedHttpContentReader` and also introduces a `MaxLengthStrategy` parameter for controlling how the server should respond to the limit.

The added test includes an example usage:

```
      val res: Future[Response] = request.content.writeToFile(file, OneMB, LinkedHttpContentReader.MaxLengthStrategy.DiscardAndThrowException).map { _ =>
        Response.Ok(file.length.toString)
      }.recoverWith {
        case ex: LinkedHttpContentReader.MaxLengthException => Future.successful(Response.plain(Status.REQUEST_ENTITY_TOO_LARGE, "413 Request Entity Too Large"))
      }
```

This allow custom responses in case the upload is too large.

I also added support to the `HttpClient` and `HttpServer` for requesting and handle `Expect: 100-continue` patterns

Example:

```
> POST /webcat30/v1/services/htmlToPdf?fileName=bosch-1234.pdf HTTP/1.1
> Host: webservice-preprod.tecalliance.services
> User-Agent: curl/7.54.0
> Accept: */*
> X-API-Key: 2BeBXg64EewdEsApWYJpK76jWDY7w4L6ZNx1gkSPH3SpLkySKMnX
> Content-Type: text/html
> Content-Length: 522759
> Expect: 100-continue
>
< HTTP/1.1 100 Continue
} [16384 bytes data]
* We are completely uploaded and fine
```

The same exception `LinkedHttpContentReader.MaxLengthException` will get thrown early (before all of the content is read) if the `Content-Length` is part of an `Expect: 100-continue` request.
