### PR TITLE
Allow to capture Netty errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val fatalWarnings = Seq(
   // Remove "params" since we often have method signatures that intentionally have the parameters, but may not be used in every implementation, also omit "patvars" since it isn't part of the default xlint:unused and isn't super helpful
   "-Ywarn-unused:imports,privates,locals",
   // Warnings become Errors
-  "-Xfatal-warnings"
+  "-Xfatal-warnings",
 )
 
 scalacOptions := Seq(

--- a/src/main/scala/fm/http/server/HttpServerOptions.scala
+++ b/src/main/scala/fm/http/server/HttpServerOptions.scala
@@ -1,6 +1,7 @@
 package fm.http.server
 
 import fm.http.Headers
+import fm.netty.exceptionhandler.{DefaultHttpServerExceptionHandler, HttpServerExceptionHandler}
 
 object HttpServerOptions {
   val default: HttpServerOptions = HttpServerOptions(None)
@@ -99,15 +100,17 @@ object HttpServerOptions {
  * @param requestHandlerExecutionContextProvider An optional RequestExecutionContextProvider instance to control which
  *                                               ExecutionContext gets passed into the RequestHandler.  Defaults to
  *                                               using the worker EventLoopGroup.
+ * @param httpServerExceptionHandler Handler for FM HTTP exceptions that occur before invoking routes
  */
 final case class HttpServerOptions(
-  requestIdResponseHeader: Option[String],
-  maxRequestsPerConnection: Long = Long.MaxValue,
-  clientIPLookupSpecs: Seq[HttpServerOptions.ClientIPLookupSpec] = Seq(HttpServerOptions.defaultClientIPLookupSpec),
-  maxInitialLineLength: Int = HttpServerOptions.defaultMaxInitialLineLength,
-  maxHeaderSize: Int = HttpServerOptions.defaultMaxHeaderSize,
-  maxChunkSize: Int = HttpServerOptions.defaultMaxChunkSize,
-  requestHandlerExecutionContextProvider: Option[RequestHandlerExecutionContextProvider] = None
+                                    requestIdResponseHeader: Option[String],
+                                    maxRequestsPerConnection: Long = Long.MaxValue,
+                                    clientIPLookupSpecs: Seq[HttpServerOptions.ClientIPLookupSpec] = Seq(HttpServerOptions.defaultClientIPLookupSpec),
+                                    maxInitialLineLength: Int = HttpServerOptions.defaultMaxInitialLineLength,
+                                    maxHeaderSize: Int = HttpServerOptions.defaultMaxHeaderSize,
+                                    maxChunkSize: Int = HttpServerOptions.defaultMaxChunkSize,
+                                    requestHandlerExecutionContextProvider: Option[RequestHandlerExecutionContextProvider] = None,
+                                    httpServerExceptionHandler: HttpServerExceptionHandler = new DefaultHttpServerExceptionHandler,
 ) {
   require(maxRequestsPerConnection > 0, "maxRequestsPerConnection must be > 0")
 }

--- a/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
+++ b/src/main/scala/fm/http/server/NettyHttpServerPipelineHandler.scala
@@ -62,7 +62,7 @@ object NettyHttpServerPipelineHandler {
 final class NettyHttpServerPipelineHandler(
   channelGroup: ChannelGroup,
   router: RequestRouter,
-  options: HttpServerOptions
+  options: HttpServerOptions,
 ) extends SimpleChannelInboundHandler[HttpObject] with Logging {
   import NettyHttpServerPipelineHandler._
   
@@ -523,7 +523,7 @@ final class NettyHttpServerPipelineHandler(
   }
   
   override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
-    logger.error(s"$id - exceptionCaught - ${ctx.channel}", cause)
+    options.httpServerExceptionHandler.doHandle(id, ctx, cause)
     if (null != contentBuilder) contentBuilder += cause
     ctx.close()
   }

--- a/src/main/scala/fm/http/server/ReloadingClassLoader.scala
+++ b/src/main/scala/fm/http/server/ReloadingClassLoader.scala
@@ -3,10 +3,12 @@ package fm.http.server
 import fm.common.IOUtils
 import fm.common.Implicits._
 import fm.common.JavaConverters._
+
 import java.io.InputStream
 import java.net.{URL, URLConnection}
-import java.security.{ProtectionDomain, Policy, CodeSource, CodeSigner}
+import java.security.{CodeSigner, CodeSource, Policy, ProtectionDomain}
 import java.util.concurrent.ConcurrentHashMap
+import scala.annotation.nowarn
 import scala.util.Try
 
 /**
@@ -41,9 +43,11 @@ final class ReloadingClassLoader(allowedPackages: Seq[String], parent: ClassLoad
   def addValidClasses(names: Iterable[String]): Unit = names.foreach { (name: String) =>
     timestamps.putIfAbsent(name, Long.MinValue)
   }
-  
+
   private[this] val protectionDomain: ProtectionDomain = {
-    val tmp = new ProtectionDomain(null, Policy.getPolicy().getPermissions(new CodeSource(null, null.asInstanceOf[Array[CodeSigner]])))    
+    // Require to been able to compile, because Policy is deprecated
+    @nowarn
+    val tmp = new ProtectionDomain(null, Policy.getPolicy.getPermissions(new CodeSource(null, null.asInstanceOf[Array[CodeSigner]])))
     // Set the default protected domain such that it doesn't reference this class 
     // loader which would prevent unloading.
     val f = classOf[ClassLoader].getDeclaredField("defaultDomain")

--- a/src/main/scala/fm/netty/exceptionhandler/DefaultHttpServerExceptionHandler.scala
+++ b/src/main/scala/fm/netty/exceptionhandler/DefaultHttpServerExceptionHandler.scala
@@ -1,0 +1,11 @@
+package fm.netty.exceptionhandler
+
+import fm.common.Logging
+import io.netty.channel.ChannelHandlerContext
+
+class DefaultHttpServerExceptionHandler extends HttpServerExceptionHandler with Logging {
+
+  override def doHandle(connectionId: Long,  ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+    logger.error(s"$connectionId - exceptionCaught - ${ctx.channel}", cause)
+  }
+}

--- a/src/main/scala/fm/netty/exceptionhandler/HttpServerExceptionHandler.scala
+++ b/src/main/scala/fm/netty/exceptionhandler/HttpServerExceptionHandler.scala
@@ -1,0 +1,8 @@
+package fm.netty.exceptionhandler
+
+import io.netty.channel.ChannelHandlerContext
+
+/** Handler for HTTP exceptions that occur before invoking routes */
+trait HttpServerExceptionHandler {
+  def doHandle(connectionId: Long, ctx: ChannelHandlerContext, cause: Throwable): Unit
+}


### PR DESCRIPTION
We had the need to be able to capture netty errors and handle then, as this lib is opensource, we wanted to keep custom implementation details outside, so the lib would only allow to register a different exception handler, which by default if not specified will work the same way.

If it's relevant the main use case, was to be able to capture **Connection Reset By Peer** errors, and log then at a different level, other than  error